### PR TITLE
fix typos and inconsistencies in cpp tutorials

### DIFF
--- a/_posts/2016-01-12-cpp-01.md
+++ b/_posts/2016-01-12-cpp-01.md
@@ -16,9 +16,9 @@ create a more friendly, less error prone and generally nicer API.
 This tutorial series will introduce you to libpmemobj  C++ bindings that leverage
 meta-programming capabilities of that language. The bindings are implemented as
 header-only library and can be found in the `src/include/libpmemobj` directory.
-All classes/functions are in the `nvml::pmem` namespace.
+All classes/functions are in the `nvml::obj` namespace.
 
-To overall goal of the libpmemobj for C++ is to focus modifications to volatile
+The overall goal of the libpmemobj for C++ is to focus modifications to volatile
 programs on data structures and not on the code. In other words, we want you to
 be able to modify your `structs` and `classes` with only slight modifications to
 your functions.

--- a/_posts/2016-01-12-cpp-02.md
+++ b/_posts/2016-01-12-cpp-02.md
@@ -10,7 +10,7 @@ variables while in a transaction. A special semi-transparent template property
 class has been implemented to automatically add variable modifications to the
 transaction undo log.
 
-### nvml::pmem::p
+### nvml::obj::p
 
 Let's start with the vector example from the previous tutorial series. It looked
 like this:
@@ -43,7 +43,7 @@ By using the C++ API we can simplify this code like so:
 {% highlight C linenos %}
 #include <libpmemobj/p.hpp>
 
-using namespace nvml::pmem;
+using namespace nvml::obj;
 
 struct vector {
 	p<int> x;
@@ -61,7 +61,7 @@ TX_BEGIN(pop) {
 } TX_END
 {% endhighlight %}
 
-The template class `nvml::pmem::p` does not add storage overhead. The size of
+The template class `nvml::obj::p` does not add storage overhead. The size of
 the vector structure is exactly the same as in the C version.
 
 This mechanism works overriding `operator=` and adding the memory to the undo log

--- a/_posts/2016-01-12-cpp-03.md
+++ b/_posts/2016-01-12-cpp-03.md
@@ -8,7 +8,7 @@ In our C API the programmer has to deal with custom pointers represented by
 the PMEMoid structure. Thanks to some macro magic we made it so that those PMEMoids
 are somewhat usable. C++ allows us to evolve this concept.
 
-### nvml::pmem::persistent_ptr
+### nvml::obj::persistent_ptr
 
 Almost everyone who ever touched a C++ code knows the idea behind smart pointers
 (for example, `std::shared_ptr`). Our persistent pointer works in the same way.
@@ -24,7 +24,7 @@ As always, we are going to start with an example:
 #include <libpmemobj/p.hpp>
 #include <libpmemobj/persistent_ptr.hpp>
 
-using namespace nvml::pmem;
+using namespace nvml::obj;
 
 struct rectangle {
 	p<int> a;

--- a/_posts/2016-01-12-cpp-04.md
+++ b/_posts/2016-01-12-cpp-04.md
@@ -6,14 +6,16 @@ layout: post
 
 The best way to learn to code is usually by implementing an example. We are going
 to be creating a linked-list based queue data structure using the the
-`nvml::pmem::p` and `nvml::pmem::persistent_ptr` classes and libpmemobj C API. But
+`nvml::obj::p` and `nvml::obj::persistent_ptr` classes and libpmemobj C API. But
 first, a little bit of CS 101 :)
 
 ## Linked-list queue
 
 Queue is a collection of elements with two important operations:
-*`push`, adds element to the `tail` of the structure
-*`pop`, removes element from the `head` of the structure
+
+* `push` - adds element to the `tail` of the structure
+* `pop` - removes element from the `head` of the structure
+
 This makes the queue a First-In-First-Out (FIFO) data structure.
 
 The common implementations use either arrays or singly linked-lists to store
@@ -21,7 +23,7 @@ elements. As previously stated, we are going to use the latter.
 
 ![queue_0](/assets/queue_0.png)
 
-### queue::push()
+### pmem_queue::push()
 
 ##### Step 1
 
@@ -48,7 +50,7 @@ we have to remember to update the `head` as well.
 
 ![queue_1_2](/assets/queue_1_2.png)
 
-### queue::pop()
+### pmem_queue::pop()
 
 ##### Step 1
 
@@ -69,7 +71,7 @@ the queue (the `head` variable is `NULL`) the `tail` variable has to be set to `
 
 When implementing algorithms that operate on persistent memory, we have to
 carefully consider what happens to the data structure if the application is
-interrupted (for example, by a power failure) at any moment during the operations.
+interrupted (for example, by a power failure) at any moment during its operation.
 
 The pmemobj library takes care of those issues and it's enough to simply wrap
 your code in a transaction block to make it failsafe atomic (i.e. done completely or
@@ -114,5 +116,5 @@ The `pmem_queue::push()` and `pmem_queue::pop()` functions look exactly like a
 volatile implementation, but with a transaction block and
 `pmemobj_alloc()`/`pmemobj_free()` instead of `new`/`delete`.
 
-The complete implementation is available
+Complete implementation is available
 [here](https://github.com/pmem/nvml/tree/master/src/examples/libpmemobj/cpp/queue.cpp).


### PR DESCRIPTION
I changed the namespace in the code, but forgot about the tutorials...