### PR TITLE
Use `rootp` in blog post

### DIFF
--- a/_posts/2015-06-13-accessing-pmem.md
+++ b/_posts/2015-06-13-accessing-pmem.md
@@ -136,7 +136,7 @@ scanf("%9s", buf);
 We read maximum of 9 bytes to the temporary buffer.
 
 {% highlight C linenos %}
-root->len = strlen(buf);
+rootp->len = strlen(buf);
 pmemobj_persist(pop, &rootp->len, sizeof (rootp->len));
 pmemobj_memcpy_persist(pop, rootp->buf, my_buf, rootp->len);
 {% endhighlight %}

--- a/_posts/2015-06-13-accessing-pmem.md
+++ b/_posts/2015-06-13-accessing-pmem.md
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 This time when we open the pool, the root object will not be zeroed - it will contain whatever string the writer was tasked with storing. So, to read it:
 
 {% highlight C linenos %}
-if (root->len == strlen(rootp->buf))
+if (rootp->len == strlen(rootp->buf))
 	printf("%s\n", rootp->buf);
 {% endhighlight %}
 


### PR DESCRIPTION
I assume this is just a typo. See the example (https://github.com/pmem/nvml/blob/master/src/examples/libpmemobj/string_store/writer.c#L68) as a reference.

Anyway, I want to thank you for this project and particularly the tutorial posts which makes it incredible easy for an novice as me to get started. :heart: 