### PR TITLE
2014-09-23-btt.md: Fix display of headings

### DIFF
--- a/_posts/2014-09-23-btt.md
+++ b/_posts/2014-09-23-btt.md
@@ -23,7 +23,7 @@ volume. It can be thought of as an extremely simple file system that only
 provides atomic sector updates.
 
 
-####The _On-disk_ Layout
+#### The _On-disk_ Layout
 
 The underlying storage on which a BTT can be laid out is not limited in any way.
 The BTT, however, splits the available space into chunks of up to 512 GiB,
@@ -36,9 +36,9 @@ in detail in [btt_layout.h](https://github.com/pmem/nvml/blob/master/src/libpmem
 
 ![Static Layout](/assets/btt-static-layout.png)
 
-####Theory of Operation
+#### Theory of Operation
 
-######The BTT Map
+###### The BTT Map
 
 The map is a simple lookup/indirection table that maps an LBA to an internal
 block. Each map entry is 32 bits. The two most significant bits are special
@@ -66,7 +66,7 @@ worth of blocks that this arena contributes, this block is at 256G. Thus, the
 block 'X' (256G) points to block 'Y', say '64'. Thus the `postmap ABA` is 64.
 
 
-######The BTT Flog
+###### The BTT Flog
 
 The BTT provides sector atomicity by making every write an "allocating write",
 i.e. Every write goes to a "free" block. A running list of free blocks is
@@ -91,7 +91,7 @@ done such that for any entry being written, it:
 - writes the new entry such that the sequence number is written last.
 
 
-######The concept of lanes
+###### The concept of lanes
 
 While 'nfree' describes the number of concurrent IOs an arena can process
 concurrently, 'nlanes' is the number of IOs the BTT device as a whole can
@@ -104,7 +104,7 @@ all the on-disk and in-memory data structures for the duration of the IO. It is
 protected by a spinlock.
 
 
-######In-memory data structure: Read Tracking Table (RTT)
+###### In-memory data structure: Read Tracking Table (RTT)
 
 Consider a case where we have two threads, one doing reads and the other,
 writes. We can hit a condition where the writer thread grabs a free block to do
@@ -124,7 +124,7 @@ RTT for its presence. If the postmap free block is in the RTT, it waits till the
 reader clears the RTT entry, and only then starts writing to it.
 
 
-######In-memory data structure: map locks
+###### In-memory data structure: map locks
 
 Consider a case where two writer threads are writing to the same LBA. There can
 be a race in the following sequence of steps:
@@ -142,7 +142,7 @@ Instead we use an array of (nfree) map_locks that is indexed by
 (premap_aba modulo nfree).
 
 
-######Reconstruction from the Flog
+###### Reconstruction from the Flog
 
 On startup, we analyze the BTT flog to create our list of free blocks. We walk
 through all the entries, and for each lane, of the set of two possible
@@ -155,7 +155,7 @@ number). The reconstruction rules/steps are simple:
   (This case can only be caused by power-fails/unsafe shutdowns)
 
 
-######Summarizing - Read and Write flows
+###### Summarizing - Read and Write flows
 
 `Read:`
 
@@ -185,7 +185,7 @@ number). The reconstruction rules/steps are simple:
 11. Release lane (and lane_lock)
 
 
-####Error Handling
+#### Error Handling
 
 An arena would be in an error state if any of the metadata is corrupted
 irrecoverably, either due to a bug or a media error. The following conditions
@@ -201,7 +201,7 @@ If any of these error conditions are encountered, the arena is put into a read
 only state using a flag in the info block.
 
 
-####Using the BTT
+#### Using the BTT
 
 An implementation of the BTT is present in the [NVM Library](/nvml/), that one
 can experiment with today!


### PR DESCRIPTION
Fix display of headings. http://pmem.io/2014/09/23/btt.html has broken
headings displaying the markdown hases in front of them. Add a space between
the hashes and the heading so Jekyll understands it.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>