### PR TITLE
cpp: clarify object destruction on deletion

### DIFF
--- a/_posts/2016-05-10-cpp-05.md
+++ b/_posts/2016-05-10-cpp-05.md
@@ -2,6 +2,7 @@
 title: "C++ bindings for libpmemobj (part 4) - pool handle wrapper"
 author: tomaszkapela
 layout: post
+identifier: cpp_05
 ---
 
 One of the necessary steps in developing the C++ libpmemobj bindings was the

--- a/_posts/2016-05-19-cpp-06.md
+++ b/_posts/2016-05-19-cpp-06.md
@@ -2,6 +2,7 @@
 title: "C++ bindings for libpmemobj (part 5) - make_persistent"
 author: tomaszkapela
 layout: post
+identifier: cpp_06
 ---
 
 One of the most important features of the C++ bindings to libpmemobj is the
@@ -66,6 +67,10 @@ delete_persistent<entry[3]>(b); /* delete persistent array 'b' */
 delete_persistent<entry[3][2]>(c); /* delete persistent array 'c' */
 {% endhighlight %}
 
+In case of transactional object destruction, the NVML library calls the object's
+destructor. This is however not the case with atomic allocations, where there
+is no way to atomically destroy and deallocate an object.
+
 Transactional allocations are the most convenient way of creating persistent
 objects, especially if the allocation is one in a sequence of operations that
 have to be made atomically with respect to persistence. There is however another
@@ -129,10 +134,27 @@ It is stated in the C API, in debug builds you get a warning log, but I still
 feel the need to reinforce this, because there is no way to generate
 a compile time error.
 
-To conclude, the atomic allocations API should only be used outside
-transactions, but it is possible to use it within transactions. The
-transactional versions can only be used within transactions. If used outside of
-transaction scope, an exception is thrown.
+To conclude:
+
+- The atomic allocations API should **NOT** be used inside transactions
+- In case of atomic deallocations the memory gets freed, but the object's
+destructor is **never called**.
+- The transactional versions can only be used within transactions. If used
+outside of transaction scope, an exception is thrown.
+
+{% highlight cpp linenos %}
+auto pop = pool_base::create(...);
+persistent_ptr<entry> pentry;
+transaction::exec_tx(pop, [&] {
+   make_persistent_atomic<entry>(pop, pentry); /* legal but dangerous */
+   auto b = make_persistent<entry>(); /* OK */
+   delete_persistent<entry>(b); /* call ~entry() and free memory */
+});
+
+make_persistent_atomic<entry>(pop, pentry); /* OK */
+auto b = make_persistent<entry>(); /* throw an exception */
+delete_persistent_atomic<entry>(pop, pentry); /* free memory, no call to ~entry() */
+{% endhighlight %}
 
 This concludes the introduction of atomic and transactional allocations. If you
 ever feel like looking at more code, try our [examples][f8602ec1] or


### PR DESCRIPTION
There is a slight but significant difference in atomic/transactional
deallocation that needs to be clarified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/40)
<!-- Reviewable:end -->
