### PR TITLE
cpp: fix typos in post

### DIFF
--- a/_posts/2016-05-25-cpp-07.md
+++ b/_posts/2016-05-25-cpp-07.md
@@ -37,7 +37,7 @@ parameter:
 
 {% highlight cpp linenos %}
 auto pop = pool_base::create(...);
-transaction::exec_tx(pop, transaction_fx, locks...);
+transaction::exec_tx(pop, transaction_fn, locks...);
 {% endhighlight %}
 
 By `locks`, I of course mean the C++ persistent memory resident locks which
@@ -110,7 +110,7 @@ the developer from the burden of manually committing the transaction.
 {% highlight cpp linenos %}
 auto pop = pool_base::create(...);
 {
-  transaction::manual tx(pop);
+  transaction::automatic tx(pop);
   auto pentry = make_persistent<entry>();
 } // here the transaction commits
 {% endhighlight %}


### PR DESCRIPTION
Misspelled transaction::automatic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/45)
<!-- Reviewable:end -->
