### PR TITLE
Fix link to documents page

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -35,7 +35,7 @@ feedback, and questions are welcome.  You can:
 
 #### More Info
 
-See the [Documents area](/Documents/) for a list
+See the [Documents area](/documents/) for a list
 of interesting publications related to persistent memory programming.
 
 You can also subscribe to this blog [via RSS](/feed.xml).


### PR DESCRIPTION
This fixes a broken link to Documents on the About page: http://pmem.io/Documents/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/73)
<!-- Reviewable:end -->
