### PR TITLE
Add an ndctl redirect to the pmem.io top bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ The content specific to PMDK, accessed by the URL http://pmem.io/pmdk,
 lives in the gh-pages branch of the pmdk repo itself (GitHub pages magic
 causes the appropriate URLs to find the appropriate content).
 
+Similarly, the content specific to ndctl, accessed by the URL
+http://pmem.io/ndctl, lives in the gh-pages branch of the ndctl repo
+itself
+
 The contents of this site are BSD-licensed open source.
 
 Send questions or comments to [andy.rudoff@intel.com](mailto:andy.rudoff@intel.com).

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,6 +23,7 @@
 			<li><a href="/glossary/" {% if page.title == "Glossary" %} class="sel" {% endif %}>Glossary</a></li>
 			<li><a href="/documents/" {% if page.title == "Documents" %} class="sel" {% endif %}>Documents</a></li>
 			<li><a href="/pmdk/" title="Persistent Memory Development Kit" {% if page.title == "PMDK" %} class="sel" {% endif %}>PMDK</a></li>
+			<li><a href="/ndctl/" title="Documentation for ndctl" {% if page.title == "ndctl" %} class="sel" {% endif %}>ndctl</a></li>
 			<li><a href="/blog/" {% if page.title == "Blog" %} class="sel" {% endif %}>Blog</a></li>
 			<li><a href="/about/" {% if page.title == "About" %} class="sel" {% endif %}>About</a></li>
 		</ul>


### PR DESCRIPTION
ndctl man pages are now available online at pmem.github.io/ndctl via the
gh-pages branch in the ndctl repo. Add a link to this from the top nav
bar in pmem.io, and update the readme to talk about ndctl/gh-pages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/74)
<!-- Reviewable:end -->
