### PR TITLE
Fixing styling issues of FIO blog post

### DIFF
--- a/_posts/2018-06-25-fio-tutorial.md
+++ b/_posts/2018-06-25-fio-tutorial.md
@@ -14,19 +14,19 @@ we commonly use it.
 For starters, links to needed software:
 * [FIO][1fioLink]
 * [NDCTL][ndctlLnk]
+
 And, of course, to execute any FIO tests using pmem engines you need PMDK
 installed in your system.
 
-Tests can be run on [emulated pmem][13rde117] or real hardware (devices
-presented to system by NVDIMM Firmware Interface Table (NFIT), according to ACPI
-Specification v6.0+). Either way you have to prepare device(s) before test
-execution. First step is to configure a namespace (emulated pmem is delivered
-already as a namespace). For this step you can use command `ndctl
-create-namespace`. There are two main options to configure namespace in our case
-- either you choose mode `fsdax` or `devdax`.
-Namespace configured with **fsdax** is a block device with support of dax
-operations. It can host a dax-capable file system (e.g. ext4 or xfs) and should
-be configured like:
+Tests can be run on [emulated pmem][13rde117] or real hardware (devices 
+presented to system by NVDIMM Firmware Interface Table (NFIT), according to ACPI 
+Specification v6.0+). Either way you have to prepare device(s) before test 
+execution. First step is to configure a namespace (emulated pmem is delivered 
+already as a namespace). For this step you can use command `ndctl 
+create-namespace`. There are two main options to configure namespace in our 
+case, either you choose mode `fsdax` or `devdax`. Namespace configured with 
+**fsdax** is a block device with support of dax operations. It can host a 
+dax-capable file system (e.g. ext4 or xfs) and should be configured like:
 {% highlight bash %}
 ndctl create-namespace --type=pmem --mode=fsdax --region=X [--align=4k]
 mkfs.ext4 /dev/pmemX
@@ -76,13 +76,16 @@ FIO is generating I/O traffic using engines specific for the job. To specify
 which engine is used in a job there's workload's option `ioengine=my_engine`.
 All of them are described in [their c file][44ku0112] and all have corresponding
 [examples][55ku0123]. Few of them are related to persistent memory:
-** libpmem **
+
+**libpmem**
+
 This engine reads/writes data using libpmem library. Works on a namespace
 created in `fsdax` mode. Full example workload for generating traffic of
 sequential reads using this engine can be found [here][fiolibPM]. There are
 additional comments within the jobfile to explain specific parameters.
 
-** dev-dax **
+**dev-dax**
+
 It also uses libpmem library, but as the name suggest it is specified to work
 with device-dax devices. Our full example workload [DaxSeqR.fio][fiodevDX]
 shows how to properly use FIO with /dev/dax. Since we don't work on a "regular"
@@ -93,21 +96,24 @@ other and results are not cached in the processor. In case FIO reads the same
 part over and over (using different threads on the same space) it ends up not
 reading from the device.
 
-** pmemblk **
+**pmemblk**
+
 This engine is using libpmemblk library. Results delivered by this engine will
 not show you the best performance of your hardware, only what this specific
 library is capable of. While using this engine, `blocksize` and
 `size` of a file are given as part of `filename` option, like here:
-{% highlight ini %}
+{% highlight bash %}
 filename=/mnt/pmem6/testjob,512,1024000
 #size=1024000M
 #bs=512
 {% endhighlight %}
+
 This is a bit different approach, comparing with other engines which use
 parameter "bs" and "size" (see commented part above). Full example workload
 doing traffic of sequential reads for pmemblk can be found [here][fioPMblk].
 
-** mmap **
+**mmap**
+
 It's the most "basic" of mentioned engines, because its purpose is just to read
 from/write to a memory mapped region. It can be used with pmem, but is not
 tailor-made. It generates traffic doing memcpy to/from memory region. Difference
@@ -117,9 +123,12 @@ Again, full example working workload is available: [MmapSeqR.fio][fioMMap1]
 
 ### Execution and results
 Command to run FIO is: `fio [options] [jobfile] ...`.
+
 Since we use workloads defined in a file (as opposed to specifying parameters
-in command line), we execute FIO with command like 
-`numactl -N 0 fio --output=my_workload.log --output-format=json my_workload.fio`.
+in command line), we execute FIO with command like:
+
+`numactl -N 0 fio --output=my_workload.log --output-format=json my_workload.fio`
+
 [numactl command][nctl1234] guarantees that processes are pinned to selected 
 numa node. The same can also be achieved by assigning CPU mask for FIO using 
 option `cpus_allowed`. We chose JSON format to save our results in 


### PR DESCRIPTION
I've corrected bold font, removed unnecessary bullet point before "either you choose", added new line signs when necessary and changed "ini" highlighting to "bash", since the first one wasn't coloring correctly FIO syntax.
This time I've tested changes on my repository, so it should work fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/80)
<!-- Reviewable:end -->
