### PR TITLE
add info for squashing commits after review

### DIFF
--- a/_posts/2014-09-09-git-workflow.md
+++ b/_posts/2014-09-09-git-workflow.md
@@ -182,5 +182,9 @@ updates.  Although this conversation happens in the pull request
 managed by GitHub, you are always welcome to ask questions and make
 suggestions to the entire team using the
 [Google Group](http://groups.google.com/group/pmem).
+* After review usually it's best to squash your commits with fixes the same
+way as described above (`git rebase -i`). When you try again to push your
+changes you may encounter git error "failed to push". In such case it's
+required to use "--force" option (`git push -f origin ...`).
 
 ###### [This entry was edited on 2017-12-11 to reflect the name change from [NVML to PMDK]({% post_url 2017-12-11-NVML-is-now-PMDK %}).]


### PR DESCRIPTION
Adding info about squashing your commits after review to git-workflow blog

you can see how it looks here:
https://lukaszstolarczuk.github.io/2014/09/09/git-workflow.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/87)
<!-- Reviewable:end -->
