### PR TITLE
blog: link fix in pmdk-convert post

### DIFF
--- a/_posts/2019-02-01-pool-conversion-tool.md
+++ b/_posts/2019-02-01-pool-conversion-tool.md
@@ -146,4 +146,4 @@ $ pmempool transform poolset2 poolset
 In 1.5 release we introduced an extra features flags. After upgrading pmdk
 (and pool conversion for libpmemobj pools), they can be turned on for
 existing pools. Detailed information about feature flags can be found in
-the [pool features] (https://pmem.io/2018/12/05/pool-features.html) blog post.
+the [pool features](https://pmem.io/2018/12/05/pool-features.html) blog post.


### PR DESCRIPTION
fix broken link in 'Pool conversion tool' blog post

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/99)
<!-- Reviewable:end -->
