### PR TITLE
Added Open Graph Metadata for Crawlers and Social Media Sharing

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -27,6 +27,13 @@
   <script src="https://kit.fontawesome.com/fa0026050e.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.1/dist/jquery.validate.min.js"></script>
+
+  <!-- Open Graph Tags for Crawlers -->
+  <meta property='og:title' content='[Book] Programming Persistent Memory: A Comprehensive Guide for Developers'/>
+  <meta property='og:image' content='https://pmem.io/book/assets/images/3d-digital-and-print-1048x705.jpg'/>
+  <meta property='og:description' content='This is a comprehensive guide to persistent memory programming, targeted towards experienced programmers. You will understand how persistent memory brings together several new software/hardware requirements, and offers great promise for better performance and faster application startup times, a huge leap forward in byte-addressable capacity compared with current DRAM offerings.'/>
+  <meta property='og:url' content='https://pmem.io/book/' />
+  <!-- End Open Graph Tags -->
   
 </head>
 <body>
@@ -368,7 +375,8 @@ $(document).ready(function() {
             Spread the persistent word!</h1>
         <amp-social-share type="email"></amp-social-share>
         <amp-social-share type="facebook" data-param-app_id="884200135290570"></amp-social-share>
-        <amp-social-share type="linkedin"></amp-social-share>
+	<amp-social-share type="linkedin">
+	</amp-social-share>
         <amp-social-share type="twitter"></amp-social-share>
         <amp-social-share type="whatsapp"></amp-social-share>
     </div>


### PR DESCRIPTION
Social Media sharing through LinkedIn, Facebook, and others relies on the OpenGraph metadata or it'll fall back to scraping the site.  I've added the `<meta property='og:* ...>` tags to ensure social media cralwers obtain the correct information when visitors share the page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/108)
<!-- Reviewable:end -->
