### PR TITLE
fix typo in rpmem library name

### DIFF
--- a/repoindex.md
+++ b/repoindex.md
@@ -48,7 +48,7 @@ organization in GitHub under
 					<li>libpmemobj
 					<li>libpmemblk
 					<li>libpmemlog
-					<li>libpmemrpmem
+					<li>librpmem
 					<li>libpmempool
 					<li>libvmem
 					<li>pmempool utility


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/111)
<!-- Reviewable:end -->
