### PR TITLE
[Book] Add Cafelli pixel tracking for Stack Overflow advertising campaign

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -483,6 +483,14 @@
                         </div>
                     </div>
                 </div>
+		<div class="row">
+		    <div class="col-md-12 col-xs-12 col-sm-12 column ui-droppable">
+			<div class="pix-content text-center">
+			    <h3 class="pix-navy-blue pix-no-margin-top secondary-font"> <span class="pix_edit_text"><span style="font-weight: bold;">Do you have 3 mins?</span></span> </h3>
+			    <p class="pix-navy-blue-2 big-text pix-margin-bottom-50"> <span class="pix_edit_text">Read <a href="https://software.intel.com/content/www/us/en/develop/articles/developer-tips-and-tricks-for-persistent-memory.html" target="_blank">"Developer Tips and Tricks for Persistent Memory"</a> to begin your PMem developer journey. The book covers these tips in detail, and much, much more!</a></span> </p>
+		    	</div>
+		    </div>
+		</div>
             </div>
         </div>
         <div class="pix_section pix-padding" id="section_features_1" style="display: block; background-color: rgb(244, 244, 244); background-repeat: repeat-x; padding-top: 60px; padding-bottom: 60px;">
@@ -652,6 +660,12 @@
                         <div class="pix-content pix-padding-top-30">
                             <h5 class="pix-black-gray-dark pix-no-margin-top"> <span class="pix_edit_text"><strong>4. Can I use the book and code examples for personal, commercial, or academic use?</strong></span> </h5>
                             <p class="pix-black-gray-light pix-margin-bottom-20 big-text"> <span class="pix_edit_text">Absolutely. <span style="font-weight: bold;">Programming Persistent Memory: A Comprehensive Guide for Developers</span> is published through <a href="https://www.apress.com/us/apress-open" target="_blank">Apress Open</a> using a <a href="https://creativecommons.org/" target="_blank">Creative Commons Attribution license</a>. You may use the book content and source code examples for any purpose. All we ask is that you attribute the book and its author.</span> </p>
+                        </div>
+                    </div>
+		    <div class="col-xs-12 col-sm-6 column ui-droppable col-md-12">
+                        <div class="pix-content pix-padding-top-30">
+                            <h5 class="pix-black-gray-dark pix-no-margin-top"> <span class="pix_edit_text"><strong>5. I encountered an error when submitting the form</strong></span> </h5>
+                            <p class="pix-black-gray-light pix-margin-bottom-20 big-text"> <span class="pix_edit_text">Absolutely. <span style="font-weight: bold;">Sorry about that. Occasionally there may be an issue on the back end. Please wait a few mins and try again. If that doesn't work, try disabling any Ad Blocker or Virus Protection that scans websites. We have found several of these plugins block the javascript that runs on this page, resulting in form submission errors. If none of this works, contact us on the <a href="https://join.slack.com/t/pmem-io/shared_invite/enQtNzU4MzQ2Mzk3MDQwLWQ1YThmODVmMGFkZWI0YTdhODg4ODVhODdhYjg3NmE4N2ViZGI5NTRmZTBiNDYyOGJjYTIyNmZjYzQxODcwNDg">#pmem Slack Channel</a> or the <a href="https://groups.google.com/forum/#!forum/pmem">PMem Forum</a>.</span> </p>
                         </div>
                     </div>
                 </div>

--- a/book/js/custom.js
+++ b/book/js/custom.js
@@ -128,12 +128,12 @@ $( window ).on("load", function() {
                          * $('.alert').slideDown();
                          */
 
-			/* Stack Overflow Ad Conversion Tracking */
+			/* Cafelli/Stack Overflow Ad Conversion Tracking */
 			var axel = Math.random()+"";
 			var a = axel * 10000000000000;
-			var stackoverflow_code = "<img src=\"https://pubads.g.doubleclick.net/activity;xsp=4681854;ord=" + a + "?\" width=1 height=1 border=0>";
+			var stackoverflow_code = "<img src=\"https://pubads.g.doubleclick.net/activity;xsp=4718423;ord=" + a + "?\" width=1 height=1 border=0>";
 			stackoverflow_code += "<noscript>";
-			stackoverflow_code += "<img src=\"https://pubads.g.doubleclick.net/activity;xsp=4681854;ord=1?\" width=1 height=1 border=0>";
+			stackoverflow_code += "<img src=\"https://pubads.g.doubleclick.net/activity;xsp=4718423;ord=1?\" width=1 height=1 border=0>";
 			stackoverflow_code += "</" + "noscript>";
 			$("#download_links").append(stackoverflow_code);
                     }, 500);


### PR DESCRIPTION
Marketing has changed from StackOverflow to Cafelli. New pixel code is required. 

Also added a link to "[Developer Tips and Tricks for Persistent Memory](https://software.intel.com/content/www/us/en/develop/articles/developer-tips-and-tricks-for-persistent-memory.html)" on the download page so the visitor has a quick introduction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/148)
<!-- Reviewable:end -->
