### PR TITLE
PM Emulation: Add reflink=0 for xfs

### DIFF
--- a/_posts/2016/2016-02-22-pm-emulation.md
+++ b/_posts/2016/2016-02-22-pm-emulation.md
@@ -97,7 +97,7 @@ For those files there is no paging, and load/store operations provide direct acc
 Install filesystem with DAX (available today for ext4 and xfs):
 {% highlight console linenos %}
 # sudo mkdir /mnt/mem
-# sudo mkfs.ext4 /dev/pmem0    OR    #sudo mkfs.xfs /dev/pmem0
+# sudo mkfs.ext4 /dev/pmem0    OR    #sudo mkfs.xfs -m reflink=0 /dev/pmem0
 # sudo mount -o dax /dev/pmem0 /mnt/mem
 {% endhighlight %}
 


### PR DESCRIPTION
Newer xfs versions have a data block sharing feature. That feature is incompatible with DAX. This PR updates the blog post accordingly.

See also:
https://kb.pmem.io/problem/100000005-Mounting-a-DAX-XFS-file-system-can-return-wrong-fs-type,-bad-option,-bad-superblock,-missing-code-page-or-helper-program/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/149)
<!-- Reviewable:end -->
