### PR TITLE
blog posts: update links to pmemcheck docs

### DIFF
--- a/_posts/2015/2015-07-17-pmemcheck-basic.md
+++ b/_posts/2015/2015-07-17-pmemcheck-basic.md
@@ -13,7 +13,7 @@ We wanted the tool to be as flexible as possible, so that it could be used with 
 
 ### Basic usage
 
-Because our tool is still a prototype, it is only available on [github][655a3db3]. Once you get the tree, you have to manually build and install it. If you have any trouble installing, look at either the provided github page or the official [Valgrind homepage][b4b537ec] for more info. If you still experience trouble building and installing pmemcheck, either contact me @tomaszkapela or file an [issue][41493750]. Once that is done, to run an application under pmemcheck type:
+Because our tool is still a prototype, it is only available on [github][655a3db3]. Once you get the tree, you have to manually build and install it. If you have any trouble installing, look at either the provided github page or the official [Valgrind homepage][b4b537ec] for more info. If you still experience trouble building and installing pmemcheck, please file an [issue][41493750]. Once that is done, to run an application under pmemcheck type:
 
 {% highlight sh %}
 $ valgrind --tool=pmemcheck [valgrind options] <your_app> [your_app options]
@@ -173,7 +173,7 @@ The first message tells you that you flushed the first store twice (you get one 
 This concludes the introduction to basic and advanced features of pmemcheck. In the next blog post I will explain how the built-in transaction support in pmemcheck works.
 
 [655a3db3]: https://github.com/pmem/valgrind "Valgrind-pmemcheck"
-[d324cfe0]: https://github.com/pmem/valgrind/blob/pmem-3.15/pmemcheck/docs/pmc-manual.xml "Pmemcheck documentation"
+[d324cfe0]: https://pmem.io/valgrind/generated/pmc-manual.html "Pmemcheck documentation"
 [b4b537ec]: https://valgrind.org/ "Valgrind"
 [41493750]: https://github.com/pmem/valgrind/issues "pmemcheck issues"
 [e0997ea1]: https://giphy.com/gifs/rainbow-unicorn-highway-G0nTMRctvIp4Q "Magic"

--- a/_posts/2015/2015-07-20-pmemcheck-transactions.md
+++ b/_posts/2015/2015-07-20-pmemcheck-transactions.md
@@ -246,7 +246,7 @@ This concludes the pmemcheck's built-in transaction support. If you want to know
 [40b153e7]: https://pmem.io/pmdk/libpmemobj/ "pmemobj"
 [57acd504]: https://pmem.io/2015/06/15/transactions.html "pmemobj transactions"
 [c749cb90]: https://pmem.io/blog/ "Blog posts"
-[d324cfe0]: https://github.com/pmem/valgrind/blob/pmem-3.15/pmemcheck/docs/pmc-manual.xml "Pmemcheck documentation"
+[d324cfe0]: https://pmem.io/valgrind/generated/pmc-manual.html "Pmemcheck documentation"
 [aa87ca41]: https://pmem.io/2015/09/16/mt-tx.html "Challenges of multi-threaded transactions"
 [051ba546]: https://github.com/pmem/valgrind/blob/pmem/pmemcheck/tests/trans_mt_cross.c "Pmemcheck test"
 


### PR DESCRIPTION
it's better to use generated version than a link to raw docs.
Remove also personal contact point and use only "issues" for troubleshooting.

// FYI, we don't seem to have any links (on pmem.io) to the pmem.io/valgrind sub-section; not sure if we want to, though 😉

// preview of updated blog posts:
https://lukaszstolarczuk.github.io/2015/07/17/pmemcheck-basic.html
https://lukaszstolarczuk.github.io/2015/07/20/pmemcheck-transactions.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/163)
<!-- Reviewable:end -->
