### PR TITLE
rpma: fix links to man pages, add man pages for v0.10.0

### DIFF
--- a/content/rpma/_index.md
+++ b/content/rpma/_index.md
@@ -18,8 +18,9 @@ The **Remote Persistent Memory Access (RPMA)** (librpma) is a C library to simpl
 
 The documentation is available for:
 
-* the current [master](/rpma/manpages/master/librpma.7.html)
-* [v0.9.0](/rpma/manpages/v0.9.0/librpma.7.html)
+* the current [master](https://github.com/pmem/rpma/tree/man-pages/manpages/master)
+* [v0.10.0](https://github.com/pmem/rpma/tree/man-pages/manpages/v0.10.0)
+* [v0.9.0](https://github.com/pmem/rpma/tree/man-pages/manpages/v0.9.0)
 
 ### Recommended reading list
 


### PR DESCRIPTION
Fix links to man pages (use temporary ones)
and add man pages for v0.10.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/195)
<!-- Reviewable:end -->
