### PR TITLE
add extra space after code block, before next content

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -708,8 +708,12 @@ p {
 
 /* Markdown highlight  */
 .highlight pre {
-  margin-bottom: 10px;
+  margin-bottom: 5px;
   padding: 10px;
+}
+
+.highlight {
+  margin-bottom: 1em; /* add extra space after code block */
 }
 
 /* Code block number alignment */


### PR DESCRIPTION
# Before:
https://pmem.io/blog/2020/01/introduction-to-libmemkind/

![image](https://user-images.githubusercontent.com/29728779/177958308-76305440-8067-4b3c-8869-45e9b9e324fa.png)

# After:
https://lukaszstolarczuk.github.io/blog/2020/01/introduction-to-libmemkind/

![image](https://user-images.githubusercontent.com/29728779/177958410-7ef10491-137f-4f36-bf7c-a2b288fc3132.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/278)
<!-- Reviewable:end -->
