### PR TITLE
update pmemstream manpages path and image

### DIFF
--- a/content/announcements/2022/pmemstream-v0-2-0-release.md
+++ b/content/announcements/2022/pmemstream-v0-2-0-release.md
@@ -15,7 +15,7 @@ hero_image: "images/news/my_news_article_hero.jpg"
 description: ""
 
 # Event image
-image: "/images/posts/pmemstream_intro.png"
+image: "https://opengraph.githubassets.com/71fe902284914ef5f1f7825d96b406339a6e5d4e/pmem/pmemstream"
 
 # Announcement category
 announcements: ['pmemstream']

--- a/data/en/pmemstream.yml
+++ b/data/en/pmemstream.yml
@@ -16,9 +16,9 @@ c_api:
                 <p>For the current <strong>master</strong> branch:</p>"
       list_items:
         list_item1:
-          content: "<a href=\"./master/manpages/libpmemstream.3.html\">libpmemstream.3</a>"
+          content: "<a href=\"./manpages/master/libpmemstream.3.html\">libpmemstream.3</a>"
         list_item2:
-          content: "<a href=\"./master/manpages/libpmemstream.7.html\">libpmemstream.7</a>"
+          content: "<a href=\"./manpages/master/libpmemstream.7.html\">libpmemstream.7</a>"
 
 #################################  Performance reports ################################# 
 performance_reports:


### PR DESCRIPTION
- better image
- correct manpages' paths

https://lukaszstolarczuk.github.io/announcements/2022/pmemstream-v0-2-0-release/
https://lukaszstolarczuk.github.io/pmemstream/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/282)
<!-- Reviewable:end -->
