### PR TITLE
fix blog posts' formatting

### DIFF
--- a/content/blog/2015/pmemcheck-transactions.md
+++ b/content/blog/2015/pmemcheck-transactions.md
@@ -180,7 +180,7 @@ static void *make_tx(void *args)
 int main(int argc, char** argv)
 {
     /* create a pool within an existing file */
-    PMEMobjpool *pop = pmemobj*create("testfile1",
+    PMEMobjpool *pop = pmemobj_create("testfile1",
         POBJ_LAYOUT_NAME(example),
         1024 * 1024 * 1024, S_IWUSR | S_IRUSR);
 
@@ -245,9 +245,9 @@ The last type of errors pmemcheck reports in context of transactions are leftove
 int main(int argc, char** argv)
 {
     /* create a pool within an existing file */
-    PMEMobjpool *pop = pmemobj*create("testfile1",
+    PMEMobjpool *pop = pmemobj_create("testfile1",
         POBJ_LAYOUT_NAME(example),
-        1024 * 1024 \_ 1024, S_IWUSR | S_IRUSR);
+        1024 * 1024 * 1024, S_IWUSR | S_IRUSR);
 
     TX_BEGIN(pop) {
     	TOID(struct my_root) root = POBJ_ROOT(pop, struct my_root);

--- a/content/blog/2015/pmemobjfs.md
+++ b/content/blog/2015/pmemobjfs.md
@@ -137,7 +137,7 @@ The data specific for directory object contains a doubly-linked list of
 directory entries.
 
 ```c++
-struct objfs*dir {
+struct objfs_dir {
     PDLL_HEAD(struct objfs_dir_entry) entries; /* directory entries */
 };
 ```
@@ -149,7 +149,7 @@ The data specific for file object contains a
 of block number and the value contains a **PMEMoid** to the data block.
 
 ```c++
-struct objfs*file {
+struct objfs_file {
     TOID(struct tree_map) blocks; /* blocks map */
 };
 ```
@@ -326,7 +326,7 @@ The next interesting operation is allocating the file blocks. The following
 listing shows how it is implemented:
 
 ```c++
-TX*BEGIN(objfs->pop) {
+TX_BEGIN(objfs->pop) {
     /* allocate blocks from requested range */
     uint64_t b_off = offset / objfs->block_size;
     uint64_t e_off = (offset + size) / objfs->block_size;

--- a/content/blog/2015/transactions.md
+++ b/content/blog/2015/transactions.md
@@ -48,14 +48,14 @@ So, this is how an entire transaction block looks like:
 ```c++
 /* TX_STAGE_NONE */
 
-TX*BEGIN(pop) {
-	/* TX*STAGE_WORK */
-} TX*ONCOMMIT {
-	/* TX*STAGE_ONCOMMIT */
-} TX*ONABORT {
-	/* TX*STAGE_ONABORT */
-} TX*FINALLY {
-	/* TX*STAGE_FINALLY */
+TX_BEGIN(pop) {
+	/* TX_STAGE_WORK */
+} TX_ONCOMMIT {
+	/* TX_STAGE_ONCOMMIT */
+} TX_ONABORT {
+	/* TX_STAGE_ONABORT */
+} TX_FINALLY {
+	/* TX_STAGE_FINALLY */
 } TX_END
 
 /* TX_STAGE_NONE */

--- a/content/blog/2015/tx-alloc.md
+++ b/content/blog/2015/tx-alloc.md
@@ -134,10 +134,10 @@ If you have been reading carefully, you should be able tell why the following fu
 
 ```c++
 void rectangle_modify(TOID(struct rectangle) rect, int new_a, int new_b) {
-TX_BEGIN(pop) {
-    TX_SET(rect, a, new_a);
-    TX_SET(rect, b, new_b);
-} TX_END
+    TX_BEGIN(pop) {
+        TX_SET(rect, a, new_a);
+        TX_SET(rect, b, new_b);
+    } TX_END
 }
 ```
 

--- a/content/blog/2015/type-safety-macros.md
+++ b/content/blog/2015/type-safety-macros.md
@@ -46,7 +46,7 @@ typedef struct pmemoid {
 ```
 
 Operating on such _persistent pointers_ is equivalent to operating on raw
-pointers to volatile objects represented by void \*. This approach is error
+pointers to volatile objects represented by void *. This approach is error
 prone and such errors are very hard to find.
 
 There is a real need to provide some mechanism which would associate
@@ -116,14 +116,14 @@ respectively:
 OID_TYPE(struct car) car1;
 OID_TYPE(struct car) car2;
 ...
-DIRECT_RW(car1)->velocity = DIRECT_RO(car2)->velocity \* 2;
+DIRECT_RW(car1)->velocity = DIRECT_RO(car2)->velocity * 2;
 ```
 
 The definition of _DIRECT_RW()_ and _DIRECT_RO()_ macros look like this:
 
 ```c++
-#define DIRECT_RW(o) ((typeof(*(o).\_type)_)pmemobj_direct((o).oid)))
-#define DIRECT_RO(o) ((const typeof (_(o).\_type)\_)pmemobj_direct((o).oid))
+#define DIRECT_RW(o) ((typeof(*(o)._type)*)pmemobj_direct((o).oid)))
+#define DIRECT_RO(o) ((const typeof (*(o)._type)*)pmemobj_direct((o).oid))
 ```
 
 ###### No declaration
@@ -147,18 +147,18 @@ The `OID_ASSIGN_TYPED()` looks like the following:
 
 ```c++
 #define OID_ASSIGN_TYPED(lhs, rhs)\
-  **builtin_choose_expr(\
-  **builtin_types_compatible_p(\
-  typeof((lhs).\_type),\
-  typeof((rhs).\_type)),\
+  __builtin_choose_expr(\
+  __builtin_types_compatible_p(\
+    typeof((lhs)._type),\
+    typeof((rhs)._type)),\
   (void) ((lhs).oid = (rhs).oid),\
-  (lhs.\_type = rhs.\_type))
+  (lhs._type = rhs._type))
 ```
 
-It utilizes the gcc builtin operator _\_\_builtin_types_compatible_p_ which checks
-the compatibility of types represented by _typed persistent pointers_. If the
+It utilizes the gcc builtin operator *__builtin_types_compatible_p* which checks
+the compatibility of types represented by *typed persistent pointers*. If the
 types are compatible the actual assignment is performed. Otherwise the fake
-assignment of _\_type_ fields is performed in order to get clear message about
+assignment of *_type* fields is performed in order to get clear message about
 the error:
 
 ```c++
@@ -220,13 +220,13 @@ The macro which declares the named union may look like this:
 
 ```c++
 #define TOID(type)\
-union _toid_##type##\_toid
+union _toid_##type##_toid
 
 #define TOID_DECLARE(type)\
 TOID(type)\
 {\
  PMEMoid oid;\
- type \*\_type;\
+ type *_type;\
 }
 ```
 
@@ -245,7 +245,7 @@ D_RW(car1)->velocity = 2 * D_RO(car2)->velocity;
 ```
 
 The name of such a declared union is obtained by concatenating the desired type
-name with a _*toid*_ prefix and a _\_toid_ postfix. The prefix is required to
+name with a *_toid_* prefix and a *_toid_* postfix. The prefix is required to
 handle the two token type names like _struct name_, _union name_ and
 _enum name_. In such case the macro expands to two tokens in which the first
 one is declared as an empty macro thus avoiding the compilation errors which
@@ -254,16 +254,16 @@ For example in case of the _struct car_ the _TOID()_ macro will expand to the
 following:
 
 ```c++
-*toid_struct car_toid
+_toid_struct car_toid
 ```
 
-The `*toid_struct` token and analogous for `enum car` and `union car` may be
+The `_toid_struct` token and analogous for `enum car` and `union car` may be
 removed by declaring the following empty macros:
 
 ```c++
-#define \_toid_struct
-#define \_toid_union
-#define \_toid_enum
+#define _toid_struct
+#define _toid_union
+#define _toid_enum
 ```
 
 In result the _typed persistent pointer_ for _struct car_ will be named
@@ -272,7 +272,7 @@ prefix and postfix. For example in case of _size_t_ type, the _TOID()_ macro
 will expand to the following:
 
 ```c++
-*toid_size_t_toid
+_toid_size_t_toid
 ```
 
 Using such mechanism it is possible to declare named unions for two-token types.
@@ -369,13 +369,13 @@ compilation time and it can be embedded in the _typed persistent pointer_ by
 modifying the _TOID_DECLARE()_ macro:
 
 ```c++
-#define TOID*DECLARE(type, type_num)\
-typedef uint8_t \_toid*##type##_toid_id[(type_num)];\
+#define TOID_DECLARE(type, type_num)\
+typedef uint8_t _toid_##type##_toid_id[(type_num)];\
 TOID(type)\
 {\
  PMEMoid oid;\
- type \*\_type;\
- \_toid_##type##\_toid_id \*\_id;\
+ type *_type;\
+ _toid_##type##_toid_id *_id;\
 }
 ```
 
@@ -383,8 +383,8 @@ The type id may be obtained using the _sizeof ()_ operator both from type and an
 object:
 
 ```c++
-#define TOID*TYPE_ID(type) (sizeof (\_toid*##type##\_toid_id))
-#define TOID_TYPE_ID_OF(obj) (sizeof (\*(obj).\_id))
+#define TOID_TYPE_ID(type) (sizeof (_toid_##type##_toid_id))
+#define TOID_TYPE_ID_OF(obj) (sizeof (*(obj)._id))
 ```
 
 The declaration of such _typed persistent pointer_ may look like this:
@@ -413,7 +413,7 @@ layout without explicitly assigning the type id. The layout declaration looks
 like this:
 
 ```c++
-\* Declaration of layout */
+/* Declaration of layout */
 POBJ_LAYOUT_BEGIN(my_layout)
 POBJ_LAYOUT_TOID(my_layout, struct car)
 POBJ_LAYOUT_TOID(my_layout, struct pen)

--- a/content/blog/2015/types.md
+++ b/content/blog/2015/types.md
@@ -110,7 +110,7 @@ struct my_root_v2 {
 To check whether your version of the layout corresponds with the existing objects, you can use following expression:
 
 ```c++
-if (TOID*VALID(D_RO(root)->data)) {
+if (TOID_VALID(D_RO(root)->data)) {
     /* can use the data ptr safely */
 } else {
     /* declared type doesn't match the object */

--- a/content/blog/2016/cpp-03.md
+++ b/content/blog/2016/cpp-03.md
@@ -57,8 +57,8 @@ As always, we are going to start with an example:
 using namespace pmem::obj;
 
 struct rectangle {
-p<int> a;
-p<int> b;
+    p<int> a;
+    p<int> b;
 };
 
 struct root {
@@ -111,8 +111,8 @@ call the constructor and destructors accordingly.
 The `persistent_ptr` class also implements a `raw_ptr()` function which returns
 a pointer to the PMEMoid - this enables usage of the C failsafe atomic API.
 
-Right now the persistent*ptr class can only be used with non-polymorphic and
-trivially default constructible classes. Those limitations \_might* be relaxed
+Right now the persistent_ptr class can only be used with non-polymorphic and
+trivially default constructible classes. Those limitations *might* be relaxed
 in later versions of the bindings.
 
 ###### [This entry was edited on 2017-12-11 to reflect the name change from [NVML to PMDK](/blog/2017/12/announcing-the-persistent-memory-development-kit).]

--- a/content/blog/2016/cpp-06.md
+++ b/content/blog/2016/cpp-06.md
@@ -90,7 +90,7 @@ When you are done with a persistent object and would like for it to be
 deallocated, you need to call the complementary `delete_persistent` function.
 
 ```c++
-delete*persistent<entry>(pentry); /* delete persistent object */
+delete_persistent<entry>(pentry); /* delete persistent object */
 delete_persistent<entry[]>(a, 3); /* delete persistent array 'a' */
 delete_persistent<entry[3]>(b);   /* delete persistent array 'b' */
 delete_persistent<entry[3][2]>(c); /* delete persistent array 'c' */
@@ -134,7 +134,7 @@ Atomic deletions of persistent pointers is done through the
 versions.
 
 ```c++
-delete*persistent_atomic<entry>(pentry); /* delete persistent object */
+delete_persistent_atomic<entry>(pentry); /* delete persistent object */
 delete_persistent_atomic<entry[]>(pentry_array, 3); /* delete persistent array 'a' */
 ```
 
@@ -148,7 +148,7 @@ This is the thing I absolutely have to convey clearly, **_atomic allocations and
 transactions do NOT mix_**. So something like the following is not a good idea:
 
 ```c++
-auto pop = pool*base::create(...);
+auto pop = pool_base::create(...);
 persistent_ptr<entry> pentry;
 transaction::exec_tx(pop, [&] {
   make_persistent_atomic<entry>(pop, pentry); /* do NOT do this */
@@ -172,12 +172,12 @@ To conclude:
   outside of transaction scope, an exception is thrown.
 
 ```c++
-auto pop = pool*base::create(...);
+auto pop = pool_base::create(...);
 persistent_ptr<entry> pentry;
 transaction::exec_tx(pop, [&] {
-make_persistent_atomic<entry>(pop, pentry); /* legal but dangerous */
-auto b = make_persistent<entry>(); /* OK */
-delete_persistent<entry>(b); /* call ~entry() and free memory */
+  make_persistent_atomic<entry>(pop, pentry); /* legal but dangerous */
+  auto b = make_persistent<entry>(); /* OK */
+  delete_persistent<entry>(b); /* call ~entry() and free memory */
 });
 
 make_persistent_atomic<entry>(pop, pentry); /* OK */

--- a/content/blog/2016/cpp-07.md
+++ b/content/blog/2016/cpp-07.md
@@ -55,8 +55,8 @@ be discouraged by the peculiar C++ lambda syntax. Here is an example:
 auto pop = pool_base::create(...);
 persistent_ptr<entry> pentry;
 transaction::exec_tx(pop, [&] {
-pentry = make_persistent<entry>();
-// make other changes inside the transaction
+  pentry = make_persistent<entry>();
+  // make other changes inside the transaction
 });
 ```
 
@@ -92,8 +92,8 @@ abort:
 ```c++
 auto pop = pool_base::create(...);
 {
-transaction::manual tx(pop);
-auto pentry = make_persistent<entry>();
+  transaction::manual tx(pop);
+  auto pentry = make_persistent<entry>();
 } // here the transaction aborts
 ```
 
@@ -113,9 +113,9 @@ is to manually commit the transaction:
 ```c++
 auto pop = pool_base::create(...);
 {
-transaction::manual tx(pop);
-auto pentry = make_persistent<entry>();
-transaction::commit(); // here the transaction commits
+  transaction::manual tx(pop);
+  auto pentry = make_persistent<entry>();
+  transaction::commit(); // here the transaction commits
 }
 ```
 
@@ -139,8 +139,8 @@ the developer from the burden of manually committing the transaction.
 ```c++
 auto pop = pool_base::create(...);
 {
-transaction::automatic tx(pop);
-auto pentry = make_persistent<entry>();
+  transaction::automatic tx(pop);
+  auto pentry = make_persistent<entry>();
 } // here the transaction commits
 ```
 

--- a/content/blog/2016/cpp-08.md
+++ b/content/blog/2016/cpp-08.md
@@ -57,7 +57,7 @@ You can use the `pmem::obj::mutex` with standard wrapper classes like:
 ```c++
 pmem::obj::mutex pmutex;
 {
-std::lock_guard<pmem::obj::mutex> lock(pmutex);
+    std::lock_guard<pmem::obj::mutex> lock(pmutex);
 }
 std::unique_lock<pmem::obj::mutex> lock(pmutex);
 ```
@@ -73,7 +73,7 @@ also very straightforward:
 pmem::obj::shared_mutex smutex;
 pmem::obj::timed_mutex tmutex;
 {
-std::shared_lock<pmem::obj::shared_mutex> lock(smutex);
+    std::shared_lock<pmem::obj::shared_mutex> lock(smutex);
 }
 std::unique_lock<pmem::obj::shared_mutex> lock(smutex);
 
@@ -92,7 +92,7 @@ persistent memory resident. The usage is also very similar:
 
 ```c++
 pmem::obj::mutex pmutex;
-pmem::obj::condition*variable cond;
+pmem::obj::condition_variable cond;
 pmutex.lock();
 cond.wait(proot->pmutex, [&]() { /* check condition here */ });
 // do some meaningful work here

--- a/content/blog/2016/cpp-ctree-conversion.md
+++ b/content/blog/2016/cpp-ctree-conversion.md
@@ -89,7 +89,7 @@ typedef T *value_type;
 key_type key;
 node *inode;
 ...
-entry \*root;
+entry *root;
 ```
 
 Change to:

--- a/content/blog/2016/windows-nvml.md
+++ b/content/blog/2016/windows-nvml.md
@@ -57,7 +57,7 @@ Windows port:
 
 #### Common Code
 
-You will only find a few areas where there are Widnows specific files
+You will only find a few areas where there are Windows specific files
 and/or directories in the repository and there were added only in
 cases where there was really no other choice; OS specific implementations
 of locks and threads for example. Use of OS compilation switches,

--- a/content/blog/2017/pmemkv-zero-copy-leaf-splits.md
+++ b/content/blog/2017/pmemkv-zero-copy-leaf-splits.md
@@ -274,8 +274,6 @@ Gains in both `Put` operation performance (our slowest operation)
 and storage efficiency for larger strings easily outweigh losses in
 storage efficiency for the specific case of very small strings. This
 seems like the right tradeoffs for the large and semi-structured
-datasets that we'd like to enable with
+datasets that we'd like to enable with [pmemkv](https://github.com/pmem/pmemkv).
 
 ###### [This entry was edited on 2017-12-11 to reflect the name change from [NVML to PMDK](/blog/2017/12/announcing-the-persistent-memory-development-kit).]
-
-[pmemkv](https://github.com/pmem/pmemkv).


### PR DESCRIPTION
Due to a change of engine (for generating website's content), some 'chars' were improperly formatted - it especially broke code snippets. It's another and last part of fixes in this area.

Fixes: #270

// Preview (example blog post):
before: https://pmem.io/blog/2017/07/using-standard-library-containers-with-persistent-memory/
after: https://lukaszstolarczuk.github.io/blog/2017/07/using-standard-library-containers-with-persistent-memory/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/335)
<!-- Reviewable:end -->
