### PR TITLE
pmdk: set libpmemblk as deprecated

### DIFF
--- a/content/pmdk/libpmemblk.md
+++ b/content/pmdk/libpmemblk.md
@@ -31,6 +31,12 @@ Man pages that contains a list of the **Windows** interfaces provided:
 
 * Man page for <a href="../manpages/windows/master/libpmemblk/libpmemblk.7.html">libpmemblk current master</a>
 
+# NOTE #
+
+> NOTICE:
+The **libpmemblk** library is deprecated since PMDK 1.13.0 release
+and will be removed in the PMDK 1.14.0 release.
+
 ### libpmemblk Examples
 
 #### More Detail Coming Soon

--- a/data/en/pmdk.yml
+++ b/data/en/pmdk.yml
@@ -18,7 +18,8 @@ libraries_section:
     library_item2:
       title: 'libpmemblk'
       content: "<p>The <strong>libpmemblk</strong> library supports arrays of pmem-resident blocks, all the same size, that are atomically updated. For example, a program keeping a cache of fixed-size objects in pmem might find this library useful.</p>
-                <p>See the <a href=\"./libpmemblk\">libpmemblk page</a> for documentation and examples.</p>"
+                <p>See the <a href=\"./libpmemblk\">libpmemblk page</a> for documentation and examples.</p>
+                <blockquote><p><strong>Note:</strong> The <strong>libpmemblk</strong> library is deprecated since PMDK 1.13.0 release and will be removed in the PMDK 1.14.0 release.</p></blockquote>"
     library_item3:
       title: 'libpmemlog'
       content: "<p>The <strong>libpmemlog</strong> library provides a pmem-resident log file. This is useful for programs like databases that append frequently to a log file.</p>

--- a/data/en/repoindex.yml
+++ b/data/en/repoindex.yml
@@ -33,7 +33,7 @@ card_groups:
                     <li>libpmem</li>
                     <li>libpmem2</li>
                     <li>libpmemobj</li>
-                    <li>libpmemblk</li>
+                    <li><s>libpmemblk</s></li>
                     <li>libpmemlog</li>
                     <li>libpmempool</li>
                     <li>libpmemset (in development)</li>


### PR DESCRIPTION
https://github.com/pmem/pmdk/pull/5538

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/338)
<!-- Reviewable:end -->
