### PR TITLE
pmdk: remove table with manpages link for removed libs

### DIFF
--- a/themes/pmem-hugo/layouts/pmdk/single.html
+++ b/themes/pmem-hugo/layouts/pmdk/single.html
@@ -27,7 +27,7 @@
   {{ $dc_title_ext := $.Scratch.Get "dc_title_ext"}}
   {{ $dc_title_ext_old := $.Scratch.Get "dc_title_ext_old"}}
 
-  {{ if in (slice "pmempool" "poolset" "rpmemd" "daxio" "pmreorder" "pmem_ctl") $dc_title }}
+  {{ if in (slice "pmempool" "poolset" "rpmemd" "daxio" "pmreorder" "pmem_ctl" "librpmem" "libpmemset") $dc_title }}
     <!-- no libraries -->
   {{ else }}
     <div id="manpage_shortcut">


### PR DESCRIPTION
Preview:
before:
https://pmem.io/pmdk/librpmem/
https://pmem.io/pmdk/libpmemset/

after:
https://lukaszstolarczuk.github.io/pmdk/librpmem/
https://lukaszstolarczuk.github.io/pmdk/libpmemset/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/349)
<!-- Reviewable:end -->
