### PR TITLE
Add PMDK 1.13.1 announcement and fix the featured announcement logic

### DIFF
--- a/content/announcements/2022/Memkind-v1-14-0-release.md
+++ b/content/announcements/2022/Memkind-v1-14-0-release.md
@@ -24,7 +24,7 @@ announcements: ['Memkind']
 type: "announcement"
 
 # Featured. Specify true or false to show on homepage
-featured: 
+featured: true
 ---
 
 We've recently released a new version of the memkind library. Many thanks to all who contributed for making this release happen.

--- a/content/announcements/2023/PMDK-v1-13-0-release.md
+++ b/content/announcements/2023/PMDK-v1-13-0-release.md
@@ -24,7 +24,7 @@ announcements: ['PMDK']
 type: "announcement"
 
 # Featured. Specify true or false to show on homepage
-featured: 
+featured: true
 ---
 
 PMDK 1.13.0 has just been released. Many thanks to everyone contributing to the release!

--- a/content/announcements/2023/PMDK-v1-13-0-release.md
+++ b/content/announcements/2023/PMDK-v1-13-0-release.md
@@ -24,7 +24,7 @@ announcements: ['PMDK']
 type: "announcement"
 
 # Featured. Specify true or false to show on homepage
-featured: true
+featured: false
 ---
 
 PMDK 1.13.0 has just been released. Many thanks to everyone contributing to the release!

--- a/content/announcements/2023/PMDK-v1-13-1-release.md
+++ b/content/announcements/2023/PMDK-v1-13-1-release.md
@@ -1,0 +1,38 @@
+---
+# News article title
+title: "PMDK v1.13.1 Release"
+
+# Creation date
+date: 2023-05-31
+
+# Publish immediately.
+draft: false
+
+# Hero image
+hero_image: "images/news/my_news_article_hero.jpg"
+
+# Brief description
+description: ""
+
+# Event image
+image: "https://opengraph.githubassets.com/73d8f958e855904dc0776a7d77d0f0d3698a65b1/pmem/pmdk"
+
+# Announcement category
+announcements: ['PMDK']
+
+# Post type
+type: "announcement"
+
+# Featured. Specify true or false to show on homepage
+featured: true
+---
+
+We are pleased to announce the PMDK 1.13.1 patch release.
+
+The 1.13.1 release: 
+
+- Greatly simplifies our testing cycle and infrastructure maintenance by leveraging GHA runners.
+- Fixes minor Valgrind instrumentation issues and memory leaks in libpmem2.
+
+The release notes and the source code are available on GitHub:
+[PMDK Version 1.13.1](https://github.com/pmem/pmdk/releases/tag/1.13.1)

--- a/content/announcements/2023/customer-letter-march-2023.md
+++ b/content/announcements/2023/customer-letter-march-2023.md
@@ -5,7 +5,7 @@ title: "Optane Customer Letter March 2023"
 # Creation date
 date: 2023-03-21
 
-# Publish immediately. 
+# Publish immediately.
 draft: false
 
 # Hero image
@@ -24,7 +24,7 @@ announcements: ['pmem']
 type: "announcement"
 
 # Featured. Specify true or false to show on homepage
-featured: 
+featured: true
 ---
 
 ## Dear Customer

--- a/themes/pmem-hugo/layouts/partials/content/announcements.html
+++ b/themes/pmem-hugo/layouts/partials/content/announcements.html
@@ -7,8 +7,8 @@
     </div>
 
     <div id="portfolio" class="portfolio row grid-container gutter-20">
-      {{ $announcements2show := where site.RegularPages "Type" "announcement" }}
-      {{ $announcements2show := $announcements2show | union (sort (where (where site.RegularPages "Type" "announcement") ".Params.featured" "=" true ) ".Params.date" "desc") }}
+      {{ $announcements2show := sort (where site.RegularPages "Type" "announcement") ".Params.date" "desc" }}
+      {{ $announcements2show := $announcements2show | intersect (where $announcements2show ".Params.featured" "=" true ) }}
       {{ range first 3 $announcements2show }} 
         {{ .Render "announcement" }}
       {{ end }}


### PR DESCRIPTION
Note: It supersedes 1.13.0 as the featured announcement.

Preview:

- https://janekmi.github.io (featured announcements) and
- https://janekmi.github.io/announcements/2023/pmdk-v1-13-1-release/ (the 1.13.1 announcement).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmem.github.io/359)
<!-- Reviewable:end -->
